### PR TITLE
Default i2c address

### DIFF
--- a/examples/accelerometer.py
+++ b/examples/accelerometer.py
@@ -3,7 +3,7 @@
 import time
 from lsm303d import LSM303D
 
-lsm = LSM303D(0x1e)
+lsm = LSM303D(0x1d)  # Change to 0x1e if you have soldered the address jumper
 
 while True:
     xyz = lsm.accelerometer()

--- a/examples/magnetometer.py
+++ b/examples/magnetometer.py
@@ -3,7 +3,7 @@
 import time
 from lsm303d import LSM303D
 
-lsm = LSM303D(0x1e)
+lsm = LSM303D(0x1d) # Change to 0x1e if you have soldered the address jumper
 
 while True:
     xyz = lsm.magnetometer()


### PR DESCRIPTION
Default sensor i2c address is `0x1d`. This change adjusts the examples accordingly.